### PR TITLE
Criação dos fluxos resources de console com scaffold

### DIFF
--- a/lib/vg_track/consoles.ex
+++ b/lib/vg_track/consoles.ex
@@ -1,0 +1,104 @@
+defmodule VgTrack.Consoles do
+  @moduledoc """
+  The Consoles context.
+  """
+
+  import Ecto.Query, warn: false
+  alias VgTrack.Repo
+
+  alias VgTrack.Consoles.Console
+
+  @doc """
+  Returns the list of consoles.
+
+  ## Examples
+
+      iex> list_consoles()
+      [%Console{}, ...]
+
+  """
+  def list_consoles do
+    Repo.all(Console)
+  end
+
+  @doc """
+  Gets a single console.
+
+  Raises `Ecto.NoResultsError` if the Console does not exist.
+
+  ## Examples
+
+      iex> get_console!(123)
+      %Console{}
+
+      iex> get_console!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_console!(id), do: Repo.get!(Console, id)
+
+  @doc """
+  Creates a console.
+
+  ## Examples
+
+      iex> create_console(%{field: value})
+      {:ok, %Console{}}
+
+      iex> create_console(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_console(attrs \\ %{}) do
+    %Console{}
+    |> Console.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a console.
+
+  ## Examples
+
+      iex> update_console(console, %{field: new_value})
+      {:ok, %Console{}}
+
+      iex> update_console(console, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_console(%Console{} = console, attrs) do
+    console
+    |> Console.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a console.
+
+  ## Examples
+
+      iex> delete_console(console)
+      {:ok, %Console{}}
+
+      iex> delete_console(console)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_console(%Console{} = console) do
+    Repo.delete(console)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking console changes.
+
+  ## Examples
+
+      iex> change_console(console)
+      %Ecto.Changeset{data: %Console{}}
+
+  """
+  def change_console(%Console{} = console, attrs \\ %{}) do
+    Console.changeset(console, attrs)
+  end
+end

--- a/lib/vg_track/consoles/console.ex
+++ b/lib/vg_track/consoles/console.ex
@@ -1,0 +1,17 @@
+defmodule VgTrack.Consoles.Console do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "consoles" do
+    field :name, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(console, attrs) do
+    console
+    |> cast(attrs, [:name])
+    |> validate_required([:name])
+  end
+end

--- a/lib/vg_track_web/controllers/console_controller.ex
+++ b/lib/vg_track_web/controllers/console_controller.ex
@@ -1,0 +1,43 @@
+defmodule VgTrackWeb.ConsoleController do
+  use VgTrackWeb, :controller
+
+  alias VgTrack.Consoles
+  alias VgTrack.Consoles.Console
+
+  action_fallback VgTrackWeb.FallbackController
+
+  def index(conn, _params) do
+    consoles = Consoles.list_consoles()
+    render(conn, "index.json", consoles: consoles)
+  end
+
+  def create(conn, %{"console" => console_params}) do
+    with {:ok, %Console{} = console} <- Consoles.create_console(console_params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", Routes.console_path(conn, :show, console))
+      |> render("show.json", console: console)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    console = Consoles.get_console!(id)
+    render(conn, "show.json", console: console)
+  end
+
+  def update(conn, %{"id" => id, "console" => console_params}) do
+    console = Consoles.get_console!(id)
+
+    with {:ok, %Console{} = console} <- Consoles.update_console(console, console_params) do
+      render(conn, "show.json", console: console)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    console = Consoles.get_console!(id)
+
+    with {:ok, %Console{}} <- Consoles.delete_console(console) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/vg_track_web/controllers/fallback_controller.ex
+++ b/lib/vg_track_web/controllers/fallback_controller.ex
@@ -1,0 +1,24 @@
+defmodule VgTrackWeb.FallbackController do
+  @moduledoc """
+  Translates controller action results into valid `Plug.Conn` responses.
+
+  See `Phoenix.Controller.action_fallback/1` for more details.
+  """
+  use VgTrackWeb, :controller
+
+  # This clause handles errors returned by Ecto's insert/update/delete.
+  def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(VgTrackWeb.ChangesetView)
+    |> render("error.json", changeset: changeset)
+  end
+
+  # This clause is an example of how to handle resources that cannot be found.
+  def call(conn, {:error, :not_found}) do
+    conn
+    |> put_status(:not_found)
+    |> put_view(VgTrackWeb.ErrorView)
+    |> render(:"404")
+  end
+end

--- a/lib/vg_track_web/router.ex
+++ b/lib/vg_track_web/router.ex
@@ -7,6 +7,8 @@ defmodule VgTrackWeb.Router do
 
   scope "/api", VgTrackWeb do
     pipe_through :api
+
+    resources "/consoles", ConsoleController, except: [:new, :edit]
   end
 
   # Enables LiveDashboard only for development

--- a/lib/vg_track_web/views/changeset_view.ex
+++ b/lib/vg_track_web/views/changeset_view.ex
@@ -1,0 +1,19 @@
+defmodule VgTrackWeb.ChangesetView do
+  use VgTrackWeb, :view
+
+  @doc """
+  Traverses and translates changeset errors.
+
+  See `Ecto.Changeset.traverse_errors/2` and
+  `VgTrackWeb.ErrorHelpers.translate_error/1` for more details.
+  """
+  def translate_errors(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, &translate_error/1)
+  end
+
+  def render("error.json", %{changeset: changeset}) do
+    # When encoded, the changeset returns its errors
+    # as a JSON object. So we just pass it forward.
+    %{errors: translate_errors(changeset)}
+  end
+end

--- a/lib/vg_track_web/views/console_view.ex
+++ b/lib/vg_track_web/views/console_view.ex
@@ -1,0 +1,19 @@
+defmodule VgTrackWeb.ConsoleView do
+  use VgTrackWeb, :view
+  alias VgTrackWeb.ConsoleView
+
+  def render("index.json", %{consoles: consoles}) do
+    %{data: render_many(consoles, ConsoleView, "console.json")}
+  end
+
+  def render("show.json", %{console: console}) do
+    %{data: render_one(console, ConsoleView, "console.json")}
+  end
+
+  def render("console.json", %{console: console}) do
+    %{
+      id: console.id,
+      name: console.name
+    }
+  end
+end

--- a/priv/repo/migrations/20221106155415_create_consoles.exs
+++ b/priv/repo/migrations/20221106155415_create_consoles.exs
@@ -1,0 +1,11 @@
+defmodule VgTrack.Repo.Migrations.CreateConsoles do
+  use Ecto.Migration
+
+  def change do
+    create table(:consoles) do
+      add :name, :string
+
+      timestamps()
+    end
+  end
+end

--- a/test/support/fixtures/consoles_fixtures.ex
+++ b/test/support/fixtures/consoles_fixtures.ex
@@ -1,0 +1,20 @@
+defmodule VgTrack.ConsolesFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `VgTrack.Consoles` context.
+  """
+
+  @doc """
+  Generate a console.
+  """
+  def console_fixture(attrs \\ %{}) do
+    {:ok, console} =
+      attrs
+      |> Enum.into(%{
+        name: "some name"
+      })
+      |> VgTrack.Consoles.create_console()
+
+    console
+  end
+end

--- a/test/vg_track/consoles_test.exs
+++ b/test/vg_track/consoles_test.exs
@@ -1,0 +1,59 @@
+defmodule VgTrack.ConsolesTest do
+  use VgTrack.DataCase
+
+  alias VgTrack.Consoles
+
+  describe "consoles" do
+    alias VgTrack.Consoles.Console
+
+    import VgTrack.ConsolesFixtures
+
+    @invalid_attrs %{name: nil}
+
+    test "list_consoles/0 returns all consoles" do
+      console = console_fixture()
+      assert Consoles.list_consoles() == [console]
+    end
+
+    test "get_console!/1 returns the console with given id" do
+      console = console_fixture()
+      assert Consoles.get_console!(console.id) == console
+    end
+
+    test "create_console/1 with valid data creates a console" do
+      valid_attrs = %{name: "some name"}
+
+      assert {:ok, %Console{} = console} = Consoles.create_console(valid_attrs)
+      assert console.name == "some name"
+    end
+
+    test "create_console/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Consoles.create_console(@invalid_attrs)
+    end
+
+    test "update_console/2 with valid data updates the console" do
+      console = console_fixture()
+      update_attrs = %{name: "some updated name"}
+
+      assert {:ok, %Console{} = console} = Consoles.update_console(console, update_attrs)
+      assert console.name == "some updated name"
+    end
+
+    test "update_console/2 with invalid data returns error changeset" do
+      console = console_fixture()
+      assert {:error, %Ecto.Changeset{}} = Consoles.update_console(console, @invalid_attrs)
+      assert console == Consoles.get_console!(console.id)
+    end
+
+    test "delete_console/1 deletes the console" do
+      console = console_fixture()
+      assert {:ok, %Console{}} = Consoles.delete_console(console)
+      assert_raise Ecto.NoResultsError, fn -> Consoles.get_console!(console.id) end
+    end
+
+    test "change_console/1 returns a console changeset" do
+      console = console_fixture()
+      assert %Ecto.Changeset{} = Consoles.change_console(console)
+    end
+  end
+end

--- a/test/vg_track_web/controllers/console_controller_test.exs
+++ b/test/vg_track_web/controllers/console_controller_test.exs
@@ -1,0 +1,84 @@
+defmodule VgTrackWeb.ConsoleControllerTest do
+  use VgTrackWeb.ConnCase
+
+  import VgTrack.ConsolesFixtures
+
+  alias VgTrack.Consoles.Console
+
+  @create_attrs %{
+    name: "some name"
+  }
+  @update_attrs %{
+    name: "some updated name"
+  }
+  @invalid_attrs %{name: nil}
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  describe "index" do
+    test "lists all consoles", %{conn: conn} do
+      conn = get(conn, Routes.console_path(conn, :index))
+      assert json_response(conn, 200)["data"] == []
+    end
+  end
+
+  describe "create console" do
+    test "renders console when data is valid", %{conn: conn} do
+      conn = post(conn, Routes.console_path(conn, :create), console: @create_attrs)
+      assert %{"id" => id} = json_response(conn, 201)["data"]
+
+      conn = get(conn, Routes.console_path(conn, :show, id))
+
+      assert %{
+               "id" => ^id,
+               "name" => "some name"
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post(conn, Routes.console_path(conn, :create), console: @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "update console" do
+    setup [:create_console]
+
+    test "renders console when data is valid", %{conn: conn, console: %Console{id: id} = console} do
+      conn = put(conn, Routes.console_path(conn, :update, console), console: @update_attrs)
+      assert %{"id" => ^id} = json_response(conn, 200)["data"]
+
+      conn = get(conn, Routes.console_path(conn, :show, id))
+
+      assert %{
+               "id" => ^id,
+               "name" => "some updated name"
+             } = json_response(conn, 200)["data"]
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, console: console} do
+      conn = put(conn, Routes.console_path(conn, :update, console), console: @invalid_attrs)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "delete console" do
+    setup [:create_console]
+
+    test "deletes chosen console", %{conn: conn, console: console} do
+      conn = delete(conn, Routes.console_path(conn, :delete, console))
+      assert response(conn, 204)
+
+      assert_error_sent 404, fn ->
+        get(conn, Routes.console_path(conn, :show, console))
+      end
+    end
+  end
+
+  defp create_console(_) do
+    console = console_fixture()
+    %{console: console}
+  end
+end


### PR DESCRIPTION
A documentação para criação automática de tasks: https://hexdocs.pm/phoenix/Mix.Tasks.Phx.Gen.html

Foi utilizado para gerar esse fluxo o seguinte código:
 `mix phx.gen.json Consoles Console consoles name:string`

O link desse tipo de pode ser visto aqui neste [Link](https://hexdocs.pm/phoenix/Mix.Tasks.Phx.Gen.Json.html)

- [x]  Migration
- [x]  Schema
- [x] Context
- [x]  Controller
- [x]  View
- [x]  Router